### PR TITLE
Bump tonic and prost dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ bytes = "1"
 futures = "0.3"
 http-body = "0.4"
 http = "0.2"
-prost = "0.7"
-tonic = "0.4"
+prost = "0.9"
+tonic = "0.6"
 
 [dev-dependencies]
 async-stream = "0.3"


### PR DESCRIPTION
- When using a newer version of prost (in my case 0.9) the crate complains that it can find the prost::Message trait.
  Bumping the version of tonic and prost fix the issue