### PR TITLE
Bump dependencies to support newer `http-body` and `http` versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ keywords = ["tonic", "testing"]
 [dependencies]
 bytes = "1"
 futures = "0.3"
-http-body = "0.4"
-http = "0.2"
-prost = "0.12"
-tonic = "0.11"
+http-body = "1.0"
+http = "1.0"
+prost = "0.13"
+tonic = "0.12"
 
 [dev-dependencies]
 async-stream = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tonic-mock"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Tyr Chen <tyr.chen@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -60,23 +60,16 @@ impl Body for MockBody {
     type Data = Bytes;
     type Error = Status;
 
-    fn poll_data(
+    fn poll_frame(
         mut self: Pin<&mut Self>,
         _: &mut Context<'_>,
-    ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
+    ) -> Poll<Option<Result<http_body::Frame<Self::Data>, Self::Error>>> {
         if !self.is_empty() {
             let msg = self.data.pop_front().unwrap();
-            Poll::Ready(Some(Ok(msg)))
+            Poll::Ready(Some(Ok(http_body::Frame::data(msg))))
         } else {
             Poll::Ready(None)
         }
-    }
-
-    fn poll_trailers(
-        self: Pin<&mut Self>,
-        _: &mut Context<'_>,
-    ) -> Poll<Result<Option<http::HeaderMap>, Self::Error>> {
-        Poll::Ready(Ok(None))
     }
 }
 /// A [`Decoder`] that knows how to decode `U`.


### PR DESCRIPTION
We can't use `tonic-mock` in projects that depend on recent versions of crates like `http-body` and `http`. This PR updates the dependency versions in `Cargo.toml` to align with newer releases.

Specifically, this change:
  *   Bumps versions for `http-body`, `http`, and related crates in `Cargo.toml`.
  *   Updates `MockBody::poll_data` in `src/mock.rs` to handle `http_body::Frame` as required by the updated `http-body` API.

With these updates, `tonic-mock` should be compatible with projects using more recent versions of the `http-body` ecosystem.